### PR TITLE
where の機能拡張

### DIFF
--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -151,22 +151,7 @@ module KintoneSync
     end
 
     def all
-      res = []
-      offset = 0
-      query = "offset #{offset}"
-      items = @api.records.get(@app_id, query, [])
-      while(items['records'].present?)
-        res += items['records']
-        offset += items['records'].count
-        query = "offset #{offset}"
-        items = @api.records.get(@app_id, query, [])
-      end
-      res
-    end
-
-    def limit(limit=0) # FIXME
-      query = "offset 0"
-      @api.records.get(@app_id, query, [])['records']
+      fetch_all_records
     end
 
     def container_type?(type)
@@ -190,14 +175,14 @@ module KintoneSync
                    "#{k} #{not_op}= \"#{v}\""
                  end
       end
-      @api.records.get(@app_id, query, [])
+      fetch_all_records(query)
     end
 
     def save pre_params, unique_key=nil
       if unique_key
         cond = {}
         cond[unique_key] = pre_params[unique_key]
-        records = where(cond)['records']
+        records = where(cond)
         if records.present?
           id = records.first['$id']['value'].to_i
           return update(id, pre_params)
@@ -306,6 +291,23 @@ module KintoneSync
       @api.records.delete(app_id, ids)
       puts 'end to delete'
       remove app_id if is_retry
+    end
+
+    private
+
+    def fetch_all_records(base_query = '')
+      res = []
+      offset = 0
+      limit = 500
+      loop do
+        query = "#{base_query} limit #{limit} offset #{offset}"
+        records = @api.records.get(@app_id, query, [])['records']
+        break unless records
+        res += records
+        break if records.count < limit
+        offset += limit
+      end
+      res
     end
   end
 end

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -169,15 +169,24 @@ module KintoneSync
       @api.records.get(@app_id, query, [])['records']
     end
 
+    def container_type?(type)
+      %w(DROP_DOWN CHECK_BOX RADIO_BUTTON).include?(type)
+    end
+
     def where cond
       query = ''
       cond.each do |k, v|
         query += ' and ' unless query == ''
-        if properties[k.to_s]['type'] == 'DROP_DOWN'
-          query += "#{k} in (\"#{v}\")"
-        else
-          query += "#{k} = \"#{v.to_s}\""
-        end
+        type = properties[k.to_s]['type']
+        query += if container_type?(type)
+                   if v.is_a?(Array)
+                     "#{k} in (\"#{v.join('","')}\")"
+                   else
+                     "#{k} in (\"#{v}\")"
+                   end
+                 else
+                   "#{k} = \"#{v}\""
+                 end
       end
       @api.records.get(@app_id, query, [])
     end

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -158,13 +158,13 @@ module KintoneSync
       %w(DROP_DOWN CHECK_BOX RADIO_BUTTON).include?(type)
     end
 
-    def where(cond, deny: false)
+    def where(cond, options = {})
       query = ''
       cond.each do |k, v|
         query += ' and ' unless query == ''
         type = properties[k.to_s]['type']
         is_container = container_type?(type)
-        not_op = is_container ? 'not' : ?! if deny
+        not_op = is_container ? 'not' : ?! if options[:not]
         query += if container_type?(type)
                    if v.is_a?(Array)
                      "#{k} #{not_op} in (\"#{v.join('","')}\")"

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -173,19 +173,21 @@ module KintoneSync
       %w(DROP_DOWN CHECK_BOX RADIO_BUTTON).include?(type)
     end
 
-    def where cond
+    def where(cond, deny: false)
       query = ''
       cond.each do |k, v|
         query += ' and ' unless query == ''
         type = properties[k.to_s]['type']
+        is_container = container_type?(type)
+        not_op = is_container ? 'not' : ?! if deny
         query += if container_type?(type)
                    if v.is_a?(Array)
-                     "#{k} in (\"#{v.join('","')}\")"
+                     "#{k} #{not_op} in (\"#{v.join('","')}\")"
                    else
-                     "#{k} in (\"#{v}\")"
+                     "#{k} #{not_op} in (\"#{v}\")"
                    end
                  else
-                   "#{k} = \"#{v}\""
+                   "#{k} #{not_op}= \"#{v}\""
                  end
       end
       @api.records.get(@app_id, query, [])


### PR DESCRIPTION
- in に対応するフィールドを増やす（チェックボックスとラジオボタン）
- 否定演算子を使えるようにする
  - `kintone.where({ flag: 'hoge' }, not: true)`
- 100件以上のレコードに対応

### 要注意事項

where の後方互換性がなくなります。

今まで
```rb
array = kintone.where( ... )["records"]
```

と ["records"] として取り出さなくてはいけなかったのが、

```
array = kintone.where( ... )
```

だけになります。（allメソッドに合わせた形）