### PR TITLE
revision を指定できるように／find_by の追加／order_by オプション

### DIFF
--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -178,6 +178,10 @@ module KintoneSync
       fetch_all_records(query)
     end
 
+    def find_by(cond, options = {})
+      where(cond, options).first
+    end
+
     def save pre_params, unique_key=nil
       if unique_key
         cond = {}

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -216,12 +216,12 @@ module KintoneSync
       res['message'] ? raise(res.inspect) : res
     end
 
-    def update id, record
+    def update id, record, revision: nil
       params = {}
       record.each do |k, v|
         params[k] = {value: v}
       end
-      @api.record.update(@app_id, id.to_i, params) 
+      @api.record.update(@app_id, id.to_i, params, revision: revision)
     end
 
     def create_all records
@@ -268,8 +268,8 @@ module KintoneSync
       res['message'] ? raise(res.inspect) : res
     end
 
-    def update! id, record
-      res = update(id, record)
+    def update! id, record, revision: nil
+      res = update(id, record, revision: revision)
       res['message'] ? raise(res.inspect) : res
     end
 
@@ -278,7 +278,7 @@ module KintoneSync
       res['message'] ? raise(res.inspect) : res
     end
 
-    def remove app_id=nil
+    def remove app_id=nil, revisions: nil
       app_id ||= @app_id
       # データ取得：上限500件
       # データ削除：上限100件
@@ -288,7 +288,7 @@ module KintoneSync
       return 'no records' if records.blank?
       ids = records.map{|r| r['$id']['value'].to_i}
       puts 'start to delete'
-      @api.records.delete(app_id, ids)
+      @api.records.delete(app_id, ids, revisions: revisions)
       puts 'end to delete'
       remove app_id if is_retry
     end

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -163,13 +163,13 @@ module KintoneSync
     end
 
     def where_query(cond, options = {})
-      query = ''
+      query = ''.dup
       cond.each do |k, v|
-        query += ' and ' unless query == ''
+        query << ' and ' unless query == ''
         type = properties[k.to_s]['type']
         is_container = container_type?(type)
         not_op = is_container ? 'not' : ?! if options[:not]
-        query += if container_type?(type)
+        query << if container_type?(type)
                    if v.is_a?(Array)
                      "#{k} #{not_op} in (\"#{v.join('","')}\")"
                    else
@@ -178,6 +178,9 @@ module KintoneSync
                  else
                    "#{k} #{not_op}= \"#{v}\""
                  end
+      end
+      if options[:order_by]
+        query << " order by #{options[:order_by]}"
       end
       query
     end

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -191,6 +191,10 @@ module KintoneSync
       @api.records.get(@app_id, query, [])['records'].first
     end
 
+    def find_each(cond, options = {})
+      where(cond, options).each
+    end
+
     def save pre_params, unique_key=nil
       if unique_key
         cond = {}

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -159,6 +159,10 @@ module KintoneSync
     end
 
     def where(cond, options = {})
+      fetch_all_records(where_query(cond, options))
+    end
+
+    def where_query(cond, options = {})
       query = ''
       cond.each do |k, v|
         query += ' and ' unless query == ''
@@ -175,11 +179,13 @@ module KintoneSync
                    "#{k} #{not_op}= \"#{v}\""
                  end
       end
-      fetch_all_records(query)
+      query
     end
 
     def find_by(cond, options = {})
-      where(cond, options).first
+      base_query = where_query(cond, options)
+      query = "#{base_query} limit 1 offset 0"
+      @api.records.get(@app_id, query, [])['records'].first
     end
 
     def save pre_params, unique_key=nil


### PR DESCRIPTION
### revision の指定
update 時などに、revision を指定することで、kintone のリビジョンチェックを有効に出来る。

```rb
params = { ... }
kitone.update!(params, revision: 2)
```

### find_by の追加

```rb
kitnone.find_by(params)

# 下記と同等の結果
kintone.where(params).first
```

`where( ... ).first` と結果は同じだが、limit 1 を指定しているため無駄にレコードを取得しない

### order_by オプション

where と find_by で order by を使えるように。

```rb
kintone.where(params, order_by: '更新日時 desc')
kintone.find_by(params, order_by: '$id asc')
など
```

### find_each の追加

```rb
where( ... ).each
```

のエイリアス