### PR TITLE
kintoneのcreateでvalidationエラーが発生すると無限ループになる

### DIFF
--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -213,14 +213,7 @@ module KintoneSync
       pre_params.each do |k, v|
         params[k] = {value: v}
       end
-      begin
-        res = @api.record.register(@app_id, params)
-      rescue
-        #sleep 5
-        sleep 0.1
-        save pre_params
-      end
-      res
+      @api.record.register(@app_id, params)
     end
 
     def create! pre_params


### PR DESCRIPTION
0.1.5以降のkintone Gemを使っているとvalidationエラー時にKintoneErrorがraiseされます。
https://github.com/jue58/kintone/commit/b9512ca418eeef355385b514e2144c483b40e8d6

今のcreateの実装はエラーが発生すると、再度saveを呼ぶようになっており、容易に無限ループが発生するので修正しておきたいです。
元々はAPI制限等によるエラーを想定していたんでしょうか…？

いずれ全体のコードを最新のgemに合わせて見直した方がよいかもしれません。（`!`が付いてないメソッドでもエラーになるなど不整合が出ている）