### PR TITLE
order by $id asc on where and all

### DIFF
--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -163,8 +163,7 @@ module KintoneSync
       previous_id = 0
       limit = 500
       loop do
-        base_query = "$id > #{previous_id} order by $id asc"
-        query = "#{base_query} limit #{limit}"
+        query = "$id > #{previous_id} order by $id asc limit #{limit}"
 
         _records = @api.records.get(@app_id, query, [])
         break if _records.blank?

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -156,7 +156,7 @@ module KintoneSync
     end
 
     def all
-      fetch_records('order by $id asc limit 500', fetch_all: true)
+      fetch_records('', fetch_all: true)
     end
 
     def container_type?(type)
@@ -324,7 +324,7 @@ module KintoneSync
       previous_id = 0
       loop do
         query = if fetch_all
-                  "$id > #{previous_id} #{base_query}"
+                  "$id > #{previous_id} order by $id asc limit 500"
                 else
                   "#{base_query} limit #{limit} offset #{offset}"
                 end

--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -156,7 +156,11 @@ module KintoneSync
     end
 
     def all
-      fetch_all_records
+      # for more than 10,000 records.
+      # https://developer.cybozu.io/hc/ja/articles/360030757312#use_id
+      query = "order by $id asc"
+
+      fetch_all_records(query)
     end
 
     def container_type?(type)
@@ -187,6 +191,10 @@ module KintoneSync
       end
       if options[:order_by]
         query << " order by #{options[:order_by]}"
+      else
+        # for more than 10,000 records.
+        # https://developer.cybozu.io/hc/ja/articles/360030757312#use_id
+        query << " order by $id asc"
       end
       query
     end


### PR DESCRIPTION
resolve #46 

# 概要
https://developer.cybozu.io/hc/ja/articles/360030757312
にあるように、2020年7月から10,000件以上のレコードを取得する場合は３種類の対応をする必要が出た。
その１つが `order by $id asc` としてソートしないようにするというものなので、order指定しない場合はそうするようにした。
（ちなみに指定しないとkintone側で `order by $id desc` になる）

# 適用方法
```
# gem 'kintone_sync', github: 'mashupwork/kintone_sync'
gem 'kintone_sync', github: 'mashupwork/kintone_sync', branch: 'issue-46'
```

# TODO
* [x] allはid指定のwhereで取得していく