### PR TITLE
一括取得方法を変更(別手段)

### DIFF
--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -156,7 +156,7 @@ module KintoneSync
     end
 
     def all
-      fetch_records('order by $id asc limit 500', fetch_all: true)
+      fetch_records('', fetch_all: true)
     end
 
     def container_type?(type)
@@ -324,7 +324,7 @@ module KintoneSync
       previous_id = 0
       loop do
         query = if fetch_all
-                  "$id > #{previous_id} #{base_query}"
+                  "$id > #{previous_id} order by $id asc limit 500"
                 else
                   "#{base_query} limit #{limit} offset #{offset}"
                 end


### PR DESCRIPTION
## #47 との差分

- `fetch_all_records` を `fetch_records` へリネーム
  - 合わせて一括取得フラグとして `fetch_all` オプションを追加
  - `where` からの呼び出しも `fetch_records` に修正
  - `fetch_all_records` は `fetch_records` のエイリアスとして互換性を維持
- `all` に対する修正を `fetch_records` に移植
  - 合わせて `all` からは呼び出す時に一括取得用のオプション~~クエリ~~を渡す https://github.com/mashupwork/kintone_sync/pull/48#discussion_r499337656