### PR TITLE
alias_methodの記述位置を修正

### DIFF
--- a/lib/kintone_sync/kintone.rb
+++ b/lib/kintone_sync/kintone.rb
@@ -312,8 +312,6 @@ module KintoneSync
 
     private
 
-    alias_method :fetch_all_records, :fetch_records
-
     def fetch_records(base_query = '', fetch_all: false)
       # for more than 10,000 records.
       # https://developer.cybozu.io/hc/ja/articles/360030757312#use_id
@@ -347,5 +345,7 @@ module KintoneSync
 
       res
     end
+
+    alias_method :fetch_all_records, :fetch_records
   end
 end


### PR DESCRIPTION
### 概要
`alias_method`の記述位置が対象メソッドよりも前にあり、`rails c`起動時にエラーが発生していたため修正しました。

### エラー内容
```
/.rbenv/versions/2.6.3/lib/ruby/gems/2.6.0/bundler/gems/kintone_sync-a54967059f7c/lib/kintone_sync/kintone.rb:315:in `alias_method': undefined method `fetch_records' for class `KintoneSync::Kintone' (NameError)
```